### PR TITLE
Build BitShares-Core Linux binaries with Ubuntu 18.04 LTS (Bionic Beaver)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,13 @@ git submodule update --init --recursive
 
 #### Create base VMs
 
-Note: for better binary compatibility we build Linux binaries on Ubuntu Xenial (16.04), for Mac and Windows builds we use the newer Ubuntu Bionic (18.04).
+Note:
+* Since BitShares-Core 6.0.0, we build Linux and macOS binaries on Ubuntu 18.04 LTS (Bionic), for Windows builds we use Ubuntu 20.04 LTS (Focal).
+* The test-6.0.0 Linux binaries were built with Ubuntu 16.04 LTS (Xenial), macOS binaries were built with Ubuntu 18.04 LTS (Bionic), Windows binaries were built with Ubuntu 20.04 LTS (Focal).
+* For earlier versions of BitShares-Core, for better binary compatibility we build Linux binaries on Ubuntu 16.04 LTS (Xenial), for Mac and Windows builds we use the newer Ubuntu 18.04 LTS (Bionic).
 
 ```
+vendor/gitian-builder/bin/make-base-vm --docker --suite focal
 vendor/gitian-builder/bin/make-base-vm --docker --suite bionic
 vendor/gitian-builder/bin/make-base-vm --docker --suite xenial
 ```
@@ -100,6 +104,22 @@ Enter `./run-gitian --help` to see the available options.
 **Note:** be sure to specify the underlying virtualization mechanism with gitian's environment variables, unless you use KVM!
 (`USE_DOCKER=1` for Docker, `USE_LXC=1` for LXC or `USE_VBOX=1` for VirtualBox.)
 
+### Build only
+
+Examples:
+
+* build Linux binaries for BitShares-Core 5.2.1:
+
+  `./run-gitian -b -O linux 5.2.1`
+
+* build macOS binaries for BitShares-Core test-6.0.0:
+
+  `./run-gitian -b -O osx test-6.0.0`
+
+* build Windows binaries for BitShares-Core 5.2.1:
+
+  `./run-gitian -b -O win 5.2.1`
+
 ### Build and sign
 
 Example: build version 3.1.0 using 3 cores and 8 gigabytes of RAM, then sign with key ID 2d2746cc:
@@ -132,21 +152,23 @@ From time to time it may become necessary to update the build descriptors, e. g.
 Such changes are likely to lead to different build results, which would invalidate existing signatures.
 Also, if a new version of bitshares-core makes such changes necessary, the change might break the build for older versions.
 
-The plan for such breaking changes is:
-
-* create a branch from master, named after the latest supported core version, immediately before the breaking commit
-* future signatures for these supported versions can be added on that branch only
-* immediately after the breaking commit, remove all signatures for no-longer supported versions from master
-
-Note: it is a bit tricky to reproduce the `3.3.1` and `3.3.2` binaries due to changes on minor version of operating systems. Please check [issue #34](https://github.com/bitshares/bitshares-gitian/issues/34) for more info.
+For ease of maintenance, we create a new branch for each new version or pre-release of BitShares-Core, and add signatures (if any) in that branch.
+Some branches may be identical and redundant.
+The master branch is kept clean for development.
 
 ### Existing branches
 
-* [3.3.1](https://github.com/bitshares/bitshares-gitian/tree/3.3.1)
-* [3.3.2](https://github.com/bitshares/bitshares-gitian/tree/3.3.2)
-* [4.0.0](https://github.com/bitshares/bitshares-gitian/tree/4.0.0)
-* [5.0.0](https://github.com/bitshares/bitshares-gitian/tree/5.0.0)
+* [test-6.0.0](https://github.com/bitshares/bitshares-gitian/tree/test-6.0.0)
+* [5.2.1](https://github.com/bitshares/bitshares-gitian/tree/5.2.1)
+* [test-5.2.1](https://github.com/bitshares/bitshares-gitian/tree/test-5.2.1)
+* [5.2.0](https://github.com/bitshares/bitshares-gitian/tree/5.2.0)
+* [test-5.2.0](https://github.com/bitshares/bitshares-gitian/tree/test-5.2.0)
 * [5.1.0](https://github.com/bitshares/bitshares-gitian/tree/5.1.0)
+* [5.0.0](https://github.com/bitshares/bitshares-gitian/tree/5.0.0)
+* [4.0.0](https://github.com/bitshares/bitshares-gitian/tree/4.0.0)
+* [3.3.2](https://github.com/bitshares/bitshares-gitian/tree/3.3.2)
+* [3.3.1](https://github.com/bitshares/bitshares-gitian/tree/3.3.1)
+  Note: it is a bit tricky to reproduce the `3.3.1` and `3.3.2` binaries due to changes on minor version of operating systems. Please check [issue #34](https://github.com/bitshares/bitshares-gitian/issues/34) for more info.
 
 ## Further Reading
 

--- a/descriptors/bitshares-core-linux.yml
+++ b/descriptors/bitshares-core-linux.yml
@@ -3,7 +3,7 @@ name: bitshares-core-linux
 enable_cache: true
 distro: ubuntu
 suites:
-- xenial
+- bionic
 architectures:
 - amd64
 packages:
@@ -15,7 +15,7 @@ packages:
 - libtool
 - automake
 - doxygen
-- libboost1.58-all-dev
+- libboost1.65-all-dev
 - zlib1g-dev
 - openssl
 - pkgconf
@@ -24,8 +24,8 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- curl-7.74.0.tar.bz2
-- openssl-1.0.2u.tar.gz
+- curl-7.79.1.tar.xz
+- openssl-1.1.1l.tar.gz
 script: |
   set -e -o pipefail
 
@@ -64,8 +64,8 @@ script: |
 
   # Build curl
   CURL="`echo curl-*`"
-  tar xfj "$CURL"
-  pushd "${CURL%.tar.bz2}"
+  tar xf "$CURL"
+  pushd "${CURL%.tar.xz}"
   PKG_CONFIG_PATH="$LIBS/lib/pkgconfig" \
     LIBS="-lz -ldl -lpthread" \
     ./configure --prefix="$LIBS" \

--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -24,7 +24,7 @@ files:
 - supplement.tar.gz
 - zlib-1.2.11.tar.gz
 - openssl-1.1.1l.tar.gz
-- curl-7.79.1.tar.xz
+- curl-7.76.1.tar.xz
 - boost_1_69_0.tar.bz2
 - MacOSX10.15.sdk.tar.xz
 - e0a171828a72a0d7ad4409489033536590008ebf.tar.gz

--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -23,8 +23,8 @@ remotes:
 files:
 - supplement.tar.gz
 - zlib-1.2.11.tar.gz
-- openssl-1.1.1i.tar.gz
-- curl-7.74.0.tar.bz2
+- openssl-1.1.1l.tar.gz
+- curl-7.79.1.tar.xz
 - boost_1_69_0.tar.bz2
 - MacOSX10.15.sdk.tar.xz
 - e0a171828a72a0d7ad4409489033536590008ebf.tar.gz
@@ -86,8 +86,8 @@ script: |
 
   # Build curl
   CURL="`echo curl-*`"
-  tar xfj "$CURL"
-  pushd "${CURL%.tar.bz2}"
+  tar xf "$CURL"
+  pushd "${CURL%.tar.xz}"
   export CFLAGS=-mmacosx-version-min=10.13
   CC="ccache ${DARWIN}clang" \
   PKG_CONFIG_PATH="$LIBS/lib/pkgconfig" ./configure --host="${DARWIN%-}" \

--- a/descriptors/bitshares-core-win.yml
+++ b/descriptors/bitshares-core-win.yml
@@ -23,8 +23,8 @@ remotes:
 files:
 - supplement.tar.gz
 - zlib-1.2.11.tar.gz
-- openssl-1.1.1i.tar.gz
-- curl-7.74.0.tar.bz2
+- openssl-1.1.1l.tar.gz
+- curl-7.79.1.tar.xz
 - boost_1_69_0.tar.bz2
 script: |
   set -e -o pipefail
@@ -79,8 +79,8 @@ script: |
 
   # Build curl
   CURL="`echo curl-*`"
-  tar xfj "$CURL"
-  pushd "${CURL%.tar.bz2}"
+  tar xf "$CURL"
+  pushd "${CURL%.tar.xz}"
   sed -i 's=-lgdi32=-lcrypt32 \0='  configure
   # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
   touch configure

--- a/run-gitian
+++ b/run-gitian
@@ -106,7 +106,6 @@ if [ -n "$BUILD" ]; then
     tar cfz inputs/supplement.tar.gz --sort=name -C ../.. supplement
 
     (
-        echo https://curl.se/download/curl-7.79.1.tar.xz 0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689
         echo https://www.openssl.org/source/openssl-1.1.1l.tar.gz 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
         if [ "$OS" = "win" -o "$OS" = "osx" ]; then
             cat <<_EOL_
@@ -116,8 +115,11 @@ _EOL_
         fi
         if [ "$OS" = "osx" ]; then
             cat <<_EOL_
+https://curl.se/download/curl-7.76.1.tar.xz 64bb5288c39f0840c07d077e30d9052e1cbb9fa6c2dc52523824cc859e679145
 https://github.com/tpoechtrager/osxcross/archive/e0a171828a72a0d7ad4409489033536590008ebf.tar.gz 7ef00c27b76745d4b44e13f291df60318588aa7b5d1788aeba5aca569ac7e989
 _EOL_
+        else
+            echo https://curl.se/download/curl-7.79.1.tar.xz 0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689
         fi
     ) | while read url sha; do
         FILE="${url##*/}"

--- a/run-gitian
+++ b/run-gitian
@@ -106,17 +106,12 @@ if [ -n "$BUILD" ]; then
     tar cfz inputs/supplement.tar.gz --sort=name -C ../.. supplement
 
     (
-        echo https://curl.se/download/curl-7.74.0.tar.bz2 0f4d63e6681636539dc88fa8e929f934cd3a840c46e0bf28c73be11e521b77a5
+        echo https://curl.se/download/curl-7.79.1.tar.xz 0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689
+        echo https://www.openssl.org/source/openssl-1.1.1l.tar.gz 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
         if [ "$OS" = "win" -o "$OS" = "osx" ]; then
             cat <<_EOL_
-https://www.openssl.org/source/openssl-1.1.1i.tar.gz e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
 https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
 https://zlib.net/zlib-1.2.11.tar.gz c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-_EOL_
-        else
-            # linux
-            cat <<_EOL_
-https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
 _EOL_
         fi
         if [ "$OS" = "osx" ]; then


### PR DESCRIPTION
Build BitShares-Core Linux binaries with Ubuntu 18.04 LTS (Bionic Beaver) and bump versions of OpenSSL and curl libraries.

Fixes #49.