### PR TITLE
Upgrade zlib version from 1.2.11 to 1.2.12

### DIFF
--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -22,7 +22,7 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- zlib-1.2.11.tar.gz
+- zlib-1.2.12.tar.gz
 - openssl-1.1.1l.tar.gz
 - curl-7.76.1.tar.xz
 - boost_1_69_0.tar.bz2

--- a/descriptors/bitshares-core-win.yml
+++ b/descriptors/bitshares-core-win.yml
@@ -22,7 +22,7 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- zlib-1.2.11.tar.gz
+- zlib-1.2.12.tar.gz
 - openssl-1.1.1l.tar.gz
 - curl-7.80.0.tar.xz
 - boost_1_69_0.tar.bz2

--- a/run-gitian
+++ b/run-gitian
@@ -110,7 +110,7 @@ if [ -n "$BUILD" ]; then
         if [ "$OS" = "win" -o "$OS" = "osx" ]; then
             cat <<_EOL_
 https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
-https://zlib.net/zlib-1.2.11.tar.gz c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+https://zlib.net/zlib-1.2.12.tar.gz 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 _EOL_
         fi
         if [ "$OS" = "osx" ]; then


### PR DESCRIPTION
The source code of `zlib` version `1.2.11` has been removed from https://zlib.net/ .