### PR TITLE
Update library versions and fix a linker warning

### DIFF
--- a/descriptors/bitshares-core-linux.yml
+++ b/descriptors/bitshares-core-linux.yml
@@ -24,8 +24,8 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- curl-7.83.1.tar.xz
-- openssl-1.1.1p.tar.gz
+- curl-7.86.0.tar.xz
+- openssl-1.1.1q.tar.gz
 script: |
   set -e -o pipefail
 

--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -57,7 +57,7 @@ script: |
   tar xfz 50e86ebca7d14372febd0af8cd098705049161b9.tar.gz
   pushd osxcross-*
   mv ../MacOSX*.sdk.tar.?z tarballs/
-  GIT_SSL_NO_VERIFY=true UNATTENDED=1 ./build.sh
+  GIT_SSL_NO_VERIFY=true UNATTENDED=1 OSX_VERSION_MIN=10.13 ./build.sh
   OSXCROSS_TARGET="`pwd`/target"
   export PATH="$PATH:$OSXCROSS_TARGET/bin"
   DARWIN="$(echo target/bin/x86_64-*clang++ | cut -d/ -f 3 | cut -d- -f 1-3 )-"
@@ -88,7 +88,6 @@ script: |
   CURL="`echo curl-*`"
   tar xf "$CURL"
   pushd "${CURL%.tar.xz}"
-  export CFLAGS=-mmacosx-version-min=10.13
   CC="ccache ${DARWIN}clang" \
   PKG_CONFIG_PATH="$LIBS/lib/pkgconfig" ./configure --host="${DARWIN%-}" \
                                                     --prefix="$LIBS" \
@@ -101,7 +100,6 @@ script: |
                                                     --disable-ldap
   make -C lib install
   make -C include install
-  unset CFLAGS
   popd
 
   # Build boost

--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -23,11 +23,11 @@ remotes:
 files:
 - supplement.tar.gz
 - zlib-1.2.13.tar.gz
-- openssl-1.1.1p.tar.gz
-- curl-7.76.1.tar.xz
+- openssl-1.1.1q.tar.gz
+- curl-7.86.0.tar.xz
 - boost_1_69_0.tar.bz2
 - MacOSX10.15.sdk.tar.xz
-- e0a171828a72a0d7ad4409489033536590008ebf.tar.gz
+- 50e86ebca7d14372febd0af8cd098705049161b9.tar.gz
 script: |
   set -e -o pipefail
 
@@ -54,7 +54,7 @@ script: |
   LIBS="`pwd`/lib"
 
   # Build osxcross
-  tar xfz e0a171828a72a0d7ad4409489033536590008ebf.tar.gz
+  tar xfz 50e86ebca7d14372febd0af8cd098705049161b9.tar.gz
   pushd osxcross-*
   mv ../MacOSX*.sdk.tar.?z tarballs/
   GIT_SSL_NO_VERIFY=true UNATTENDED=1 ./build.sh

--- a/descriptors/bitshares-core-win.yml
+++ b/descriptors/bitshares-core-win.yml
@@ -23,8 +23,8 @@ remotes:
 files:
 - supplement.tar.gz
 - zlib-1.2.13.tar.gz
-- openssl-1.1.1p.tar.gz
-- curl-7.83.1.tar.xz
+- openssl-1.1.1q.tar.gz
+- curl-7.86.0.tar.xz
 - boost_1_69_0.tar.bz2
 script: |
   set -e -o pipefail

--- a/run-gitian
+++ b/run-gitian
@@ -106,7 +106,8 @@ if [ -n "$BUILD" ]; then
     tar cfz inputs/supplement.tar.gz --sort=name -C ../.. supplement
 
     (
-        echo https://www.openssl.org/source/openssl-1.1.1p.tar.gz bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f
+        echo https://www.openssl.org/source/openssl-1.1.1q.tar.gz d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca
+        echo https://curl.se/download/curl-7.86.0.tar.xz 2d61116e5f485581f6d59865377df4463f2e788677ac43222b496d4e49fb627b
         if [ "$OS" = "win" -o "$OS" = "osx" ]; then
             cat <<_EOL_
 https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
@@ -114,12 +115,7 @@ https://zlib.net/zlib-1.2.13.tar.gz b3a24de97a8fdbc835b9833169501030b8977031bcb5
 _EOL_
         fi
         if [ "$OS" = "osx" ]; then
-            cat <<_EOL_
-https://curl.se/download/curl-7.76.1.tar.xz 64bb5288c39f0840c07d077e30d9052e1cbb9fa6c2dc52523824cc859e679145
-https://github.com/tpoechtrager/osxcross/archive/e0a171828a72a0d7ad4409489033536590008ebf.tar.gz 7ef00c27b76745d4b44e13f291df60318588aa7b5d1788aeba5aca569ac7e989
-_EOL_
-        else
-            echo https://curl.se/download/curl-7.83.1.tar.xz 2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4
+            echo https://github.com/tpoechtrager/osxcross/archive/50e86ebca7d14372febd0af8cd098705049161b9.tar.gz d0496d5874a3252c4df7ce24bd724e453f85c513505b970e039fd01638fc1ff7
         fi
     ) | while read url sha; do
         FILE="${url##*/}"


### PR DESCRIPTION
Note:
* This PR updates `curl` version to `7.86.0` for all operating systems, including macOS, so https://github.com/bitshares/bitshares-core/pull/2665 is required.
  * The issue was: https://github.com/bitshares/bitshares-gitian/pull/51#issuecomment-955172224.
* This PR fixes a set of linker warnings like `ld: warning: object file (/home/ubuntu/build/lib/lib/libcurl.a(libcurl_la-easy.o)) was built for newer OSX version (10.13) than being linked (10.9)`