### PR TITLE
Build all BitShares-Core binaries in Ubuntu 20.04, and bump library versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ git submodule update --init --recursive
 #### Create base VMs
 
 Note:
-* Since BitShares-Core 6.0.0, we build Linux and macOS binaries on Ubuntu 18.04 LTS (Bionic), for Windows builds we use Ubuntu 20.04 LTS (Focal).
-* The test-6.0.0 Linux binaries were built with Ubuntu 16.04 LTS (Xenial), macOS binaries were built with Ubuntu 18.04 LTS (Bionic), Windows binaries were built with Ubuntu 20.04 LTS (Focal).
+* Since BitShares-Core test-7.0.0, we build all binaries on Ubuntu 20.04 LTS (Focal).
+* Before BitShares-Core test-7.0.0 and since BitShares-Core 6.0.0, we build Linux and macOS binaries on Ubuntu 18.04 LTS (Bionic), and for Windows builds we use Ubuntu 20.04 LTS (Focal).
+* The test-6.0.0, test-6.0.1 and test-6.0.2 Linux binaries were built with Ubuntu 16.04 LTS (Xenial), macOS binaries were built with Ubuntu 18.04 LTS (Bionic), Windows binaries were built with Ubuntu 20.04 LTS (Focal).
 * For earlier versions of BitShares-Core, for better binary compatibility we build Linux binaries on Ubuntu 16.04 LTS (Xenial), for Mac and Windows builds we use the newer Ubuntu 18.04 LTS (Bionic).
 
 ```

--- a/descriptors/bitshares-core-linux.yml
+++ b/descriptors/bitshares-core-linux.yml
@@ -3,7 +3,7 @@ name: bitshares-core-linux
 enable_cache: true
 distro: ubuntu
 suites:
-- bionic
+- focal
 architectures:
 - amd64
 packages:
@@ -15,7 +15,7 @@ packages:
 - libtool
 - automake
 - doxygen
-- libboost1.65-all-dev
+- libboost1.71-all-dev
 - zlib1g-dev
 - openssl
 - pkgconf
@@ -82,13 +82,19 @@ script: |
   cd bitshares
   cp libraries/wallet/wallet_api_impl.cpp{,.orig}
   sed -i '/__DATE__/d' libraries/wallet/wallet_api_impl.cpp
+  # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
+  touch libraries/wallet/wallet_api_impl.cpp
   # Workaround for #1791
   sed -i '/target_link_lib/s=..Boost_LIBRARIES.==;/target_link_lib/s=ZLIB_LIBRARIES.=\0 ${Boost_LIBRARIES}=' \
       libraries/fc/CMakeLists.txt
+  # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
+  touch libraries/fc/CMakeLists.txt
   # Allow static openssl, see #1980
   sed -i -e '/set..OLD_SUFF/ifind_package(OpenSSL REQUIRED)' \
       -e 's=ssl crypto=${OPENSSL_LIBRARIES} ${BOOST_THREAD_LIBRARY} ${CMAKE_DL_LIBS}=' \
       CMakeLists.txt
+  # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
+  touch CMakeLists.txt
 
   git tag -d tobuild || true # Remove tag added by gitian-builder
 

--- a/descriptors/bitshares-core-linux.yml
+++ b/descriptors/bitshares-core-linux.yml
@@ -24,8 +24,8 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- curl-7.86.0.tar.xz
-- openssl-1.1.1s.tar.gz
+- curl-8.1.2.tar.xz
+- openssl-1.1.1u.tar.gz
 script: |
   set -e -o pipefail
 

--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -23,8 +23,8 @@ remotes:
 files:
 - supplement.tar.gz
 - zlib-1.2.13.tar.gz
-- openssl-1.1.1s.tar.gz
-- curl-7.86.0.tar.xz
+- openssl-1.1.1u.tar.gz
+- curl-8.1.2.tar.xz
 - boost_1_69_0.tar.bz2
 - MacOSX10.15.sdk.tar.xz
 - 50e86ebca7d14372febd0af8cd098705049161b9.tar.gz

--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -3,7 +3,7 @@ name: bitshares-core-osx
 enable_cache: true
 distro: ubuntu
 suites:
-- bionic
+- focal
 architectures:
 - amd64
 packages:
@@ -17,6 +17,7 @@ packages:
 - doxygen
 - libssl-dev
 - libxml2-dev
+- libz-dev
 remotes:
 - url: https://github.com/bitshares/bitshares-core.git
   dir: bitshares
@@ -108,6 +109,8 @@ script: |
   pushd "${BOOST%.tar.bz2}"
   # See https://github.com/boostorg/context/issues/101
   sed -i '/os.\(name\|platform\)/d;/local tmp = /s=elf=pe=;/local tmp = /s=sysv=ms=' libs/context/build/Jamfile.v2
+  # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
+  touch libs/context/build/Jamfile.v2
   echo "using clang : osxcross : ccache ${DARWIN}clang++ : <archiver>${DARWIN}ar <ranlib>${DARWIN}ranlib ;" > user-config.jam
   ./bootstrap.sh --prefix=$LIBS --with-toolset=darwin
   ./b2 --user-config=user-config.jam \
@@ -125,10 +128,20 @@ script: |
 
   cd bitshares
   sed -i '/__DATE__/d' libraries/wallet/wallet_api_impl.cpp
+  # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
+  touch libraries/wallet/wallet_api_impl.cpp
   sed -i "/[ep].configure/s/$/ --host=${DARWIN%-} CC=${DARWIN}clang LD=${DARWIN}clang/" libraries/fc/CMakeLists.txt
+  # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
+  touch libraries/fc/CMakeLists.txt
   sed -i '/CheckLib\(rary\|cxxAtomic\)/d' libraries/fc/CMakeLists.txt
+  # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
+  touch libraries/fc/CMakeLists.txt
   sed -i '1ilist( APPEND PLATFORM_SPECIFIC_LIBS -Wl,-undefined -Wl,dynamic_lookup)' programs/witness_node/CMakeLists.txt
+  # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
+  touch programs/witness_node/CMakeLists.txt
   sed -i '1iadd_compile_options( -fvisibility=hidden )' CMakeLists.txt
+  # touch the file to get around an inline sed issue, see https://github.com/docker/machine/issues/4824
+  touch CMakeLists.txt
 
   git tag -d tobuild || true # Remove tag added by gitian-builder
 

--- a/descriptors/bitshares-core-win.yml
+++ b/descriptors/bitshares-core-win.yml
@@ -23,8 +23,8 @@ remotes:
 files:
 - supplement.tar.gz
 - zlib-1.2.13.tar.gz
-- openssl-1.1.1s.tar.gz
-- curl-7.86.0.tar.xz
+- openssl-1.1.1u.tar.gz
+- curl-8.1.2.tar.xz
 - boost_1_69_0.tar.bz2
 script: |
   set -e -o pipefail

--- a/run-gitian
+++ b/run-gitian
@@ -106,8 +106,8 @@ if [ -n "$BUILD" ]; then
     tar cfz inputs/supplement.tar.gz --sort=name -C ../.. supplement
 
     (
-        echo https://www.openssl.org/source/openssl-1.1.1s.tar.gz c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa
-        echo https://curl.se/download/curl-7.86.0.tar.xz 2d61116e5f485581f6d59865377df4463f2e788677ac43222b496d4e49fb627b
+        echo https://www.openssl.org/source/openssl-1.1.1u.tar.gz e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6
+        echo https://curl.se/download/curl-8.1.2.tar.xz 31b1118eb8bfd43cd95d9a3f146f814ff874f6ed3999b29d94f4d1e7dbac5ef6
         if [ "$OS" = "win" -o "$OS" = "osx" ]; then
             cat <<_EOL_
 https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406


### PR DESCRIPTION
- base image for building binaries
  - Linux: Ubuntu 18.04 LTS -> Ubuntu 20.04 LTS
  - macOS: Ubuntu 18.04 LTS -> Ubuntu 20.04 LTS
- Libraries
  - OpenSSL 1.1.1s -> 1.1.1u
  - CURL 7.86.0 -> 8.1.2