### PR TITLE
Update dependency versions, add note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Some branches may be identical and redundant.
 The master branch is kept clean for development.
 
 ### Existing branches
+
+Note: The source code of the `zlib-1.2.13` library has been removed from the official website (https://zlib.net). As a result, Windows binaries and macOS binaries of BitShares-Core built with the following branches can no longer be rebuilt or verified as-is.
 * [test-7.0.1](https://github.com/bitshares/bitshares-gitian/tree/test-7.0.1)
 * [test-7.0.0](https://github.com/bitshares/bitshares-gitian/tree/test-7.0.0)
 * [6.1.0](https://github.com/bitshares/bitshares-gitian/tree/6.1.0)

--- a/descriptors/bitshares-core-linux.yml
+++ b/descriptors/bitshares-core-linux.yml
@@ -24,8 +24,8 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- curl-8.1.2.tar.xz
-- openssl-1.1.1u.tar.gz
+- curl-8.2.1.tar.xz
+- openssl-1.1.1v.tar.gz
 script: |
   set -e -o pipefail
 

--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -23,9 +23,9 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- zlib-1.2.13.tar.gz
-- openssl-1.1.1u.tar.gz
-- curl-8.1.2.tar.xz
+- zlib-1.3.tar.gz
+- openssl-1.1.1v.tar.gz
+- curl-8.2.1.tar.xz
 - boost_1_69_0.tar.bz2
 - MacOSX10.15.sdk.tar.xz
 - 50e86ebca7d14372febd0af8cd098705049161b9.tar.gz

--- a/descriptors/bitshares-core-win.yml
+++ b/descriptors/bitshares-core-win.yml
@@ -22,9 +22,9 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- zlib-1.2.13.tar.gz
-- openssl-1.1.1u.tar.gz
-- curl-8.1.2.tar.xz
+- zlib-1.3.tar.gz
+- openssl-1.1.1v.tar.gz
+- curl-8.2.1.tar.xz
 - boost_1_69_0.tar.bz2
 script: |
   set -e -o pipefail

--- a/run-gitian
+++ b/run-gitian
@@ -106,13 +106,11 @@ if [ -n "$BUILD" ]; then
     tar cfz inputs/supplement.tar.gz --sort=name -C ../.. supplement
 
     (
-        echo https://www.openssl.org/source/openssl-1.1.1u.tar.gz e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6
-        echo https://curl.se/download/curl-8.1.2.tar.xz 31b1118eb8bfd43cd95d9a3f146f814ff874f6ed3999b29d94f4d1e7dbac5ef6
+        echo https://www.openssl.org/source/openssl-1.1.1v.tar.gz d6697e2871e77238460402e9362d47d18382b15ef9f246aba6c7bd780d38a6b0
+        echo https://curl.se/download/curl-8.2.1.tar.xz dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894
         if [ "$OS" = "win" -o "$OS" = "osx" ]; then
-            cat <<_EOL_
-https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
-https://zlib.net/zlib-1.2.13.tar.gz b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
-_EOL_
+            echo https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
+            echo https://zlib.net/zlib-1.3.tar.gz ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
         fi
         if [ "$OS" = "osx" ]; then
             echo https://github.com/tpoechtrager/osxcross/archive/50e86ebca7d14372febd0af8cd098705049161b9.tar.gz d0496d5874a3252c4df7ce24bd724e453f85c513505b970e039fd01638fc1ff7


### PR DESCRIPTION
- OpenSSL: 1.1.1u -> 1.1.1v
- CURL: 8.1.2 -> 8.2.1
- zlib: 1.2.13 -> 1.3

Add to README: since the source code of zlib version 1.2.13 has been removed from its official website https://zlib.net, the old build scripts no longer work.