### PR TITLE
Update dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The master branch is kept clean for development.
 
 ### Existing branches
 
+Note: The source code of the `zlib-1.3` library has been removed from the official website (https://zlib.net). As a result, Windows binaries and macOS binaries of BitShares-Core built with the following branches can no longer be rebuilt or verified as-is.
 * [7.0.2](https://github.com/bitshares/bitshares-gitian/tree/7.0.2)
 * [test-7.0.4](https://github.com/bitshares/bitshares-gitian/tree/test-7.0.4)
 * [7.0.1](https://github.com/bitshares/bitshares-gitian/tree/7.0.1)

--- a/descriptors/bitshares-core-linux.yml
+++ b/descriptors/bitshares-core-linux.yml
@@ -24,7 +24,7 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- curl-8.5.0.tar.xz
+- curl-8.6.0.tar.xz
 - openssl-1.1.1w.tar.gz
 script: |
   set -e -o pipefail

--- a/descriptors/bitshares-core-linux.yml
+++ b/descriptors/bitshares-core-linux.yml
@@ -74,6 +74,7 @@ script: |
                 --disable-ldap \
                 --with-zlib \
                 --with-ssl \
+                --without-libpsl \
                 --disable-tftp \
                 --disable-ldap
   make $MAKEOPTS install

--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -97,6 +97,7 @@ script: |
                                                     --disable-ldap \
                                                     --with-zlib="$LIBS" \
                                                     --with-ssl="$LIBS" \
+                                                    --without-libpsl \
                                                     --disable-tftp \
                                                     --disable-ldap
   make -C lib install

--- a/descriptors/bitshares-core-osx.yml
+++ b/descriptors/bitshares-core-osx.yml
@@ -23,9 +23,9 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- zlib-1.3.tar.gz
+- zlib-1.3.1.tar.gz
 - openssl-1.1.1w.tar.gz
-- curl-8.5.0.tar.xz
+- curl-8.6.0.tar.xz
 - boost_1_69_0.tar.bz2
 - MacOSX10.15.sdk.tar.xz
 - 50e86ebca7d14372febd0af8cd098705049161b9.tar.gz

--- a/descriptors/bitshares-core-win.yml
+++ b/descriptors/bitshares-core-win.yml
@@ -22,9 +22,9 @@ remotes:
   dir: bitshares
 files:
 - supplement.tar.gz
-- zlib-1.3.tar.gz
+- zlib-1.3.1.tar.gz
 - openssl-1.1.1w.tar.gz
-- curl-8.5.0.tar.xz
+- curl-8.6.0.tar.xz
 - boost_1_69_0.tar.bz2
 script: |
   set -e -o pipefail

--- a/descriptors/bitshares-core-win.yml
+++ b/descriptors/bitshares-core-win.yml
@@ -91,6 +91,7 @@ script: |
                                                     --disable-ldap \
                                                     --with-zlib \
                                                     --without-ssl --with-winssl \
+                                                    --without-libpsl \
                                                     --disable-tftp \
                                                     --disable-ldap
   make $MAKEOPTS install

--- a/run-gitian
+++ b/run-gitian
@@ -107,10 +107,10 @@ if [ -n "$BUILD" ]; then
 
     (
         echo https://www.openssl.org/source/openssl-1.1.1w.tar.gz cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
-        echo https://curl.se/download/curl-8.5.0.tar.xz 42ab8db9e20d8290a3b633e7fbb3cec15db34df65fd1015ef8ac1e4723750eeb
+        echo https://curl.se/download/curl-8.6.0.tar.xz 3ccd55d91af9516539df80625f818c734dc6f2ecf9bada33c76765e99121db15
         if [ "$OS" = "win" -o "$OS" = "osx" ]; then
             echo https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
-            echo https://zlib.net/zlib-1.3.tar.gz ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
+            echo https://zlib.net/zlib-1.3.1.tar.gz 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
         fi
         if [ "$OS" = "osx" ]; then
             echo https://github.com/tpoechtrager/osxcross/archive/50e86ebca7d14372febd0af8cd098705049161b9.tar.gz d0496d5874a3252c4df7ce24bd724e453f85c513505b970e039fd01638fc1ff7


### PR DESCRIPTION
- Update dependency versions
  - CURL: 8.5.0 -> 8.6.0
  - zlib: 1.3 -> 1.3.1

- Compile curl without libpsl
  Libpsl is required since curl 8.6.0, but we don't really need it.